### PR TITLE
Add type detection

### DIFF
--- a/src/Functions/Abs.php
+++ b/src/Functions/Abs.php
@@ -2,6 +2,7 @@
 
 namespace Iter\Functions;
 
+use Exception;
 use Iter\Types\Iter;
 
 /**
@@ -11,12 +12,16 @@ use Iter\Types\Iter;
  */
 trait Abs
 {
-    public function abs(): self
+    /**
+     * @return Iter
+     * @throws Exception
+     */
+    public function abs(): Iter
     {
         $arr = [];
         foreach ($this->arr as $v) {
             $arr[] = $v < 0 ? -$v : $v;
         }
-        return self::with($arr);
+        return Iter::with($arr);
     }
 }

--- a/src/Functions/All.php
+++ b/src/Functions/All.php
@@ -11,6 +11,10 @@ use Iter\Types\Iter;
  */
 trait All
 {
+    /**
+     * @param callable $fn
+     * @return bool
+     */
     public function all(callable $fn): bool
     {
         if (empty($this->arr)) {

--- a/src/Functions/Any.php
+++ b/src/Functions/Any.php
@@ -11,6 +11,10 @@ use Iter\Types\Iter;
  */
 trait Any
 {
+    /**
+     * @param $fn
+     * @return bool
+     */
     public function any($fn): bool
     {
         if (empty($this->arr)) {

--- a/src/Functions/Average.php
+++ b/src/Functions/Average.php
@@ -11,6 +11,9 @@ use Iter\Types\Iter;
  */
 trait Average
 {
+    /**
+     * @return float
+     */
     public function average(): float
     {
         if (count($this->arr) === 0) {

--- a/src/Functions/Break_.php
+++ b/src/Functions/Break_.php
@@ -2,6 +2,7 @@
 
 namespace Iter\Functions;
 
+use Exception;
 use Iter\Types\Iter;
 
 /**
@@ -13,7 +14,8 @@ trait Break_
 {
     /**
      * @param callable|null $fn
-     * @return self[]
+     * @return array
+     * @throws Exception
      */
     public function break_(?callable $fn): array
     {
@@ -21,7 +23,7 @@ trait Break_
         $after = [];
 
         if (is_null($fn)) {
-            return [self::with($before), self::with($this->arr)];
+            return [Iter::with($before), Iter::with($this->arr)];
         }
 
         $passed = false;
@@ -35,6 +37,6 @@ trait Break_
             }
         }
 
-        return [self::with($before), self::with($after)];
+        return [Iter::with($before), Iter::with($after)];
     }
 }

--- a/src/Functions/Delete.php
+++ b/src/Functions/Delete.php
@@ -11,7 +11,7 @@ use Iter\Types\Iter;
  */
 trait Delete
 {
-    public function delete($value): self
+    public function delete($value): Iter
     {
         $out = [];
         $deleted = false;
@@ -22,6 +22,6 @@ trait Delete
                 $deleted = true;
             }
         }
-        return self::with($out);
+        return Iter::with($out);
     }
 }

--- a/src/Functions/Map.php
+++ b/src/Functions/Map.php
@@ -2,6 +2,7 @@
 
 namespace Iter\Functions;
 
+use Exception;
 use Iter\Types\Iter;
 
 /**
@@ -14,16 +15,17 @@ trait Map
     /**
      * @param callable $fn
      * @return Map
+     * @throws Exception
      */
-    public function map(?callable $fn): self
+    public function map(?callable $fn): Iter
     {
         if (is_null($fn)) {
-            return self::with($this->arr);
+            return Iter::with($this->arr);
         }
         $arr = [];
         foreach ($this->arr as $v) {
             $arr[] = call_user_func($fn, $v);
         }
-        return self::with($arr);
+        return Iter::with($arr);
     }
 }

--- a/src/Types/Ints.php
+++ b/src/Types/Ints.php
@@ -3,6 +3,7 @@
 namespace Iter\Types;
 
 use Iter\Functions\{All, Any, Average, Break_, Delete, Map, Abs};
+use Exception;
 
 class Ints extends Iter
 {
@@ -14,7 +15,12 @@ class Ints extends Iter
         , Delete
         , Map;
 
-    public static function with($arr): self
+    /**
+     * @param $arr
+     * @return Iter
+     * @throws Exception
+     */
+    public static function with($arr): Iter
     {
         return new self($arr);
     }

--- a/src/Types/Iter.php
+++ b/src/Types/Iter.php
@@ -2,21 +2,65 @@
 
 namespace Iter\Types;
 
-abstract class Iter
+use Exception;
+
+class Iter
 {
     /** @var array */
     protected $arr;
 
-    abstract protected function verifyType();
+    /**
+     * @throws Exception
+     */
+    protected function verifyType()
+    {
+//        throw new Exception("Iter Verify Type not yet implemented");
+    }
 
+    /**
+     * Iter constructor.
+     * @param $arr
+     * @throws Exception
+     */
     protected function __construct($arr)
     {
         $this->arr = is_array($arr) ? $arr : [$arr];
         $this->verifyType();
     }
 
+    /**
+     * @return array
+     */
     public function get(): array
     {
         return $this->arr;
+    }
+
+    /**
+     * @param $arr
+     * @return static
+     * @throws Exception
+     */
+    public static function with($arr): self
+    {
+        if (empty($arr)) {
+            return new Iter($arr);
+        }
+
+        $firstElement = reset($arr);
+        $type = gettype($firstElement);
+
+        switch ($type) {
+            case "string":
+                return Strings::with($arr);
+                break;
+            case "integer":
+                return Ints::with($arr);
+                break;
+            default:
+                return new Iter([]);
+//                echo $type;
+//                throw new \InvalidArgumentException("Unrecognised type sent to Iter.");
+        }
     }
 }

--- a/src/Types/Strings.php
+++ b/src/Types/Strings.php
@@ -3,6 +3,8 @@
 namespace Iter\Types;
 
 use Iter\Functions\{All, Any, Break_, Delete, Map};
+use Exception;
+use InvalidArgumentException;
 
 class Strings extends Iter
 {
@@ -12,7 +14,12 @@ class Strings extends Iter
         , Delete
         , Map;
 
-    public static function with($arr): self
+    /**
+     * @param $arr
+     * @return Iter
+     * @throws Exception
+     */
+    public static function with($arr): Iter
     {
         return new self($arr);
     }
@@ -21,7 +28,7 @@ class Strings extends Iter
     {
         foreach ($this->arr as $v) {
             if (!is_string($v)) {
-                throw new \InvalidArgumentException("Strings value must contain only string values.");
+                throw new InvalidArgumentException("Strings value must contain only string values.");
             }
         }
     }

--- a/tests/GeneralTest.php
+++ b/tests/GeneralTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests;
+
+use Exception;
+use Iter\Types\Ints;
+use Iter\Types\Strings;
+
+class GeneralTest extends MainTestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testTypeDetection(): void
+    {
+        $ints = Ints::with([1, 2, 3, 4, 5]);
+        $strings = $ints->map(function ($v) { return (string)$v . " is a string."; });
+        $this->assertInstanceOf(Strings::class, $strings);
+        foreach ($strings->get() as $string) {
+            $this->assertEquals(gettype($string), "string");
+        }
+    }
+}


### PR DESCRIPTION
> Removed a few Exceptions until I know how I want to handle them.

> Added type detection upon use of `Iter::with`. Functions that are now used within `Ints` / `Strings` will now detect their first element's type and use the corresponding class (`Ints` / `Strings`). The reason for this is to enable type changes on maps etc. This will come in handy when we allow Objects, such as:

```php
// Where 20 / 30 = their age property
$objs = Objs::with([new Person(20), new Person(30)]);

// Grabbing the ages would previously have tried to use Objs::with([20, 30]) and failed.
$ages = $objs->map(function($v) { return $v->age; });
```

> This will now infer the type, as `map` returns `Iter::with`, which detects the type of the first element (20) and thus uses `Ints::with` instead, so we can continue to iterate over their ages.